### PR TITLE
Fixed typos in resourcedefns.sh

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@
 .vscode/*
 Blog.txt
 package-lock.json
+.env

--- a/docs/_scripts/_resourcedefns.sh
+++ b/docs/_scripts/_resourcedefns.sh
@@ -13,8 +13,9 @@
 # ToDo:
 #        * Test that the $InputFiles variable is not empty !
 #        * Convert the outputs into Reunite/Realm/Markdoc format
+#        * Remove empty line before header2 and header3 lines when there are two empty lines.
 
-# version 0.11
+# version 0.12
 
 # Local Variables
 InputFiles=$(ls ${WorkingDirectory}/_${iLOGen}_resourcedefns${iLOVersion}.*)
@@ -77,9 +78,9 @@ breadcrumbs:
   Header1Title="# ${ResourceType^} resource definitions of ${ilogen} v${iLOFwVersion}\n\n"
   FileDescription="For each data type provided by the HPE ilO Redfish service, \
 find below its description including the list of possible instances (URIs), \
-links to related other resources, described properties and many other details. \
+links to related other resources, described properties and many other details.\
 \n\n\
-Refer to the [data types and collection](/docs/concepts/dataTypesAndCollections.md) section for more information on Redfish data types and collections.\n\n"
+Refer to the [data types and collection](/docs/concepts/dataTypesAndCollections.md) section for more information on Redfish data types and collections.\n"
 
   # Output file creation with seo, title and description.
   echo -e "${SEO}${Header1Title}${FileDescription}" > $OutputFile
@@ -94,14 +95,18 @@ Refer to the [data types and collection](/docs/concepts/dataTypesAndCollections.
   #    7. Insert a blank line before "Resource Instances"
   #    8. Insert a blank line before "is an array containing elements of:"
   #    9. Fix fragment in tables like "Links to Other Resources" tables: "|`.*`|Collection of [.*](#.*)|"
-  sed -e 's/```/`/g'                                                                    \
-      -e 's/^\(### .*\)$/\1\n/'                                                         \
-      -e 's/^\(## .*\)\.v.*\..*$/\1\n/'                                                 \
-      -e 's/\[\(.*\.v.\)_\(.*\)_\(.*\..*\)\]\(.*\)$/\[\1\\_\2\\_\3\]\4/'                \
-      -e 's/(\(#.*\)-v.*-.*)/(\1)/'                                                     \
-      -e 's/^\(## .*Collection\)\..*Collection$/\1/'                                    \
-      -e '/### Resource Instances/i\\'                                                  \
-      -e '/is an array containing elements of:/i\\'                                     \
+  #   10. Append "|" to `Links to Other Resources` tables
+  #   11. Insert a blank line after "## .*Collection" header2 lines
+  sed -e 's/```/`/g'                                                       \
+      -e 's/^\(### .*\)$/\1\n/'                                            \
+      -e 's/^\(## .*\)\.v.*\..*$/\1\n/'                                    \
+      -e 's/\[\(.*\.v.\)_\(.*\)_\(.*\..*\)\]\(.*\)$/\[\1\\_\2\\_\3\]\4/'   \
+      -e 's/(\(#.*\)-v.*-.*)/(\1)/'                                        \
+      -e 's/^\(## .*Collection\)\..*Collection$/\1/'                       \
+      -e '/### Resource Instances/i\\'                                     \
+      -e '/is an array containing elements of:/i\\'                        \
+      -e '/Link Name|Destination type/s/$/|/'                              \
+      -e '/^## .*Collection/a\\'                                           \
       $file >> $OutputFile
   echo "Done."
 done

--- a/docs/_scripts/_script_wrapper.sh
+++ b/docs/_scripts/_script_wrapper.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/bash
 
-# Version 0.99
+# Version 0.991
 
 # Script name: _script_wrapper.sh 
 # This script is a wrapper to the other scripts contained in this folder, except
@@ -29,7 +29,6 @@
 
 # ToDo:
 #       * Include `events.md` when possible
-#       * Remove the oldest version of firmware to keep only the last 5 versions
 #        
 
 #
@@ -43,8 +42,8 @@ required_executables="dos2unix sed awk"
 
 # Don't forget to update the following variables to process the right iLO version !
 
-export ilogen="iLO 7"
-export iLOFwVersion=1.11
+export ilogen="iLO 6"
+export iLOFwVersion=1.68
 
 export iLOGen=$(echo ${ilogen,,} | tr -d ' ')
 export iLOVersion=$(echo $iLOFwVersion | tr -d '.')
@@ -250,12 +249,13 @@ while [ $i -le $index ] ; do
   i=$((i + 1))
 done
 
+# Uncomment the following line in case of broken links in the Changelog file.
 # Removal of the internal links Changelog file to avoid broken links.
 # Note: awk is used to search for lines between @startPattern and 
-# the next "## iLO n new"
-startPattern="## ${ilogen} v${iLOFwVersion} new"
-endPattern="$(awk -v sp="$startPattern" -v ig="## $ilogen new" '$0 ~ sp {found=1; next} found && $0 ~ ig {print; found=0}' ${iLOGen}_changelog.md)"
-sed -i "/$startPattern/,/$endPattern/ s/\[\(.*\)\](.*)/\1/g" ${iLOGen}_changelog.md
+# the next "## iLO n new".
+#startPattern="## ${ilogen} v${iLOFwVersion} new"
+#endPattern="$(awk -v sp="$startPattern" -v ig="## $ilogen new" '$0 ~ sp {found=1; next} found && $0 ~ ig {print; found=0}' ${iLOGen}_changelog.md)"
+#sed -i "/$startPattern/,/$endPattern/ s/\[\(.*\)\](.*)/\1/g" ${iLOGen}_changelog.md
 
 
 exit 0

--- a/docs/redfishServices/ilos/ilo6/ilo6_168/ilo6_bios_resourcedefns168.md
+++ b/docs/redfishServices/ilos/ilo6/ilo6_168/ilo6_bios_resourcedefns168.md
@@ -13,10 +13,9 @@ breadcrumbs:
 
 # Bios resource definitions of iLO 6 v1.68
 
-For each data type provided by the HPE ilO Redfish service, find below its description including the list of possible instances (URIs), links to related other resources, described properties and many other details. 
+For each data type provided by the HPE ilO Redfish service,find below its description including the list of possible instances (URIs),links to related other resources, described properties and many other details.
 
 Refer to the [data types and collection](/docs/concepts/dataTypesAndCollections.md) section for more information on Redfish data types and collections.
-
 
 ## Bios
 
@@ -33,7 +32,7 @@ The Bios schema contains properties related to the BIOS Attribute Registry.  The
 
 ### Links to other Resources
 
-|Link Name|Destination type
+|Link Name|Destination type|
 |---|---|
 |`Oem/Hpe/Links/Boot`|[HpeServerBootSettings](ilo6_hpe_resourcedefns168/#hpeserverbootsettings)|
 |`@Redfish.Settings/SettingsObject`|[Bios](ilo6_bios_resourcedefns168/#bios)|

--- a/docs/redfishServices/ilos/ilo6/ilo6_168/ilo6_chassis_resourcedefns168.md
+++ b/docs/redfishServices/ilos/ilo6/ilo6_168/ilo6_chassis_resourcedefns168.md
@@ -13,12 +13,12 @@ breadcrumbs:
 
 # Chassis resource definitions of iLO 6 v1.68
 
-For each data type provided by the HPE ilO Redfish service, find below its description including the list of possible instances (URIs), links to related other resources, described properties and many other details. 
+For each data type provided by the HPE ilO Redfish service,find below its description including the list of possible instances (URIs),links to related other resources, described properties and many other details.
 
 Refer to the [data types and collection](/docs/concepts/dataTypesAndCollections.md) section for more information on Redfish data types and collections.
 
-
 ## ChassisCollection
+
 `@odata.type: "#ChassisCollection.ChassisCollection"`
 
 A Collection of Chassis resource instances.
@@ -31,7 +31,7 @@ A Collection of Chassis resource instances.
 
 ### Links to other Resources
 
-|Link Name|Destination type
+|Link Name|Destination type|
 |---|---|
 |`Members[]`|[Chassis](ilo6_chassis_resourcedefns168/#chassis)|
 
@@ -76,7 +76,7 @@ The Chassis resource describes the physical components for a system. This object
 
 ### Links to other Resources
 
-|Link Name|Destination type
+|Link Name|Destination type|
 |---|---|
 |`Links/ComputerSystems[]`|[ComputerSystem](ilo6_computersystem_resourcedefns168/#computersystem)|
 |`ThermalSubsystem`|[ThermalSubsystem](ilo6_other_resourcedefns168/#thermalsubsystem)|

--- a/docs/redfishServices/ilos/ilo6/ilo6_168/ilo6_computersystem_resourcedefns168.md
+++ b/docs/redfishServices/ilos/ilo6/ilo6_168/ilo6_computersystem_resourcedefns168.md
@@ -13,12 +13,12 @@ breadcrumbs:
 
 # Computersystem resource definitions of iLO 6 v1.68
 
-For each data type provided by the HPE ilO Redfish service, find below its description including the list of possible instances (URIs), links to related other resources, described properties and many other details. 
+For each data type provided by the HPE ilO Redfish service,find below its description including the list of possible instances (URIs),links to related other resources, described properties and many other details.
 
 Refer to the [data types and collection](/docs/concepts/dataTypesAndCollections.md) section for more information on Redfish data types and collections.
 
-
 ## ComputerSystemCollection
+
 `@odata.type: "#ComputerSystemCollection.ComputerSystemCollection"`
 
 A Collection of ComputerSystem resource instances.
@@ -31,7 +31,7 @@ A Collection of ComputerSystem resource instances.
 
 ### Links to other Resources
 
-|Link Name|Destination type
+|Link Name|Destination type|
 |---|---|
 |`Members[]`|[ComputerSystem](ilo6_computersystem_resourcedefns168/#computersystem)|
 
@@ -76,7 +76,7 @@ The ComputerSystem resource describes the compute node and its properties. A Com
 
 ### Links to other Resources
 
-|Link Name|Destination type
+|Link Name|Destination type|
 |---|---|
 |`EthernetInterfaces`|Collection of [EthernetInterface](ilo6_network_resourcedefns168/#ethernetinterfacecollection)|
 |`Oem/Hpe/Links/USBDevices`|Collection of [HpeUSBDevice](#hpeusbdevice)|
@@ -2101,7 +2101,7 @@ The type of reset.
 
 |Value|Description|
 |---|---|
-|GracefulRestart|Instead of doing the graceful restart, the server does a force restart.|
+|GracefulRestart|Instead of doing a graceful restart, the server does a force restart.|
 |GracefulShutdown|Shut down gracefully and power off.|
 |PowerCycle|Power cycle the unit.|
 |On|Turn on the unit.|

--- a/docs/redfishServices/ilos/ilo6/ilo6_168/ilo6_hpe_resourcedefns168.md
+++ b/docs/redfishServices/ilos/ilo6/ilo6_168/ilo6_hpe_resourcedefns168.md
@@ -13,10 +13,9 @@ breadcrumbs:
 
 # Hpe resource definitions of iLO 6 v1.68
 
-For each data type provided by the HPE ilO Redfish service, find below its description including the list of possible instances (URIs), links to related other resources, described properties and many other details. 
+For each data type provided by the HPE ilO Redfish service,find below its description including the list of possible instances (URIs),links to related other resources, described properties and many other details.
 
 Refer to the [data types and collection](/docs/concepts/dataTypesAndCollections.md) section for more information on Redfish data types and collections.
-
 
 ## HpeAutomaticCertEnrollment
 
@@ -328,7 +327,7 @@ The HpeCertAuth resource describes the BMC certificate based authentication feat
 
 ### Links to other Resources
 
-|Link Name|Destination type
+|Link Name|Destination type|
 |---|---|
 |`CACertificates`|Collection of [HpeCertificate](ilo6_hpe_resourcedefns168/#hpecertificatecollection)|
 |`Links/UserCertificateMapping`|Collection of [HpeiLOAccountCertificateMap](ilo6_hpe_resourcedefns168/#hpeiloaccountcertificatemapcollection)|
@@ -518,6 +517,7 @@ Member of [HpeCertificate.v1\_0\_0.HpeCertificate](#hpecertificate)
 |Format|date-time|
 
 ## HpeCertificateCollection
+
 `@odata.type: "#HpeCertificateCollection.HpeCertificateCollection"`
 
 A Collection of HpeCertificate resource instances.
@@ -531,7 +531,7 @@ A Collection of HpeCertificate resource instances.
 
 ### Links to other Resources
 
-|Link Name|Destination type
+|Link Name|Destination type|
 |---|---|
 |`Members[]`|[HpeCertificate](ilo6_hpe_resourcedefns168/#hpecertificate)|
 
@@ -782,6 +782,7 @@ Member of [HpeComponent.v1\_0\_1.HpeComponent](#hpecomponent)
 |Added|iLO6 1.05|
 
 ## HpeComponentCollection
+
 `@odata.type: "#HpeComponentCollection.HpeComponentCollection"`
 
 A Collection of HpeComponent resource instances.
@@ -794,7 +795,7 @@ A Collection of HpeComponent resource instances.
 
 ### Links to other Resources
 
-|Link Name|Destination type
+|Link Name|Destination type|
 |---|---|
 |`Members[]`|[HpeComponent](ilo6_hpe_resourcedefns168/#hpecomponent)|
 
@@ -1031,6 +1032,7 @@ Member of [HpeComponentInstallSet.v1\_5\_0.HpeComponentInstallSet](#hpecomponent
 
 Previous items in the task queue can be cleared before the Install Set is invoked
 ## HpeComponentInstallSetCollection
+
 `@odata.type: "#HpeComponentInstallSetCollection.HpeComponentInstallSetCollection"`
 
 A Collection of HpeComponentInstallSet resource instances.
@@ -1043,7 +1045,7 @@ A Collection of HpeComponentInstallSet resource instances.
 
 ### Links to other Resources
 
-|Link Name|Destination type
+|Link Name|Destination type|
 |---|---|
 |`Members[]`|[HpeComponentInstallSet](ilo6_hpe_resourcedefns168/#hpecomponentinstallset)|
 
@@ -1358,6 +1360,7 @@ Member of [HpeComponentUpdateTask.v1\_5\_0.HpeComponentUpdateTask](#hpecomponent
 |Added|iLO6 1.05|
 
 ## HpeComponentUpdateTaskQueueCollection
+
 `@odata.type: "#HpeComponentUpdateTaskQueueCollection.HpeComponentUpdateTaskQueueCollection"`
 
 A Collection of HpeComponentUpdateTaskQueue resource instances.
@@ -1370,7 +1373,7 @@ A Collection of HpeComponentUpdateTaskQueue resource instances.
 
 ### Links to other Resources
 
-|Link Name|Destination type
+|Link Name|Destination type|
 |---|---|
 |`Members[]`|[HpeComponentUpdateTask](ilo6_hpe_resourcedefns168/#hpecomponentupdatetask)|
 
@@ -1836,6 +1839,7 @@ Member of [HpeiLOAccountCertificateMap.v1\_0\_1.HpeiLOAccountCertificateMap](#hp
 |Added|iLO6 1.05|
 
 ## HpeiLOAccountCertificateMapCollection
+
 `@odata.type: "#HpeiLOAccountCertificateMapCollection.HpeiLOAccountCertificateMapCollection"`
 
 A Collection of HpeiLOAccountCertificateMap resource instances.
@@ -1848,7 +1852,7 @@ A Collection of HpeiLOAccountCertificateMap resource instances.
 
 ### Links to other Resources
 
-|Link Name|Destination type
+|Link Name|Destination type|
 |---|---|
 |`Members[]`|[HpeiLOAccountCertificateMap](ilo6_hpe_resourcedefns168/#hpeiloaccountcertificatemap)|
 
@@ -2139,6 +2143,7 @@ Member of [HpeiLOBackupFile.v1\_0\_0.HpeiLOBackupFile](#hpeilobackupfile)
 Member of [HpeiLOBackupFile.v1\_0\_0.HpeiLOBackupFile](#hpeilobackupfile)
 There are no parameters for this action.
 ## HpeiLOBackupFileCollection
+
 `@odata.type: "#HpeiLOBackupFileCollection.HpeiLOBackupFileCollection"`
 
 A Collection of HpeiLOBackupFile resource instances.
@@ -2151,7 +2156,7 @@ A Collection of HpeiLOBackupFile resource instances.
 
 ### Links to other Resources
 
-|Link Name|Destination type
+|Link Name|Destination type|
 |---|---|
 |`Members[]`|[HpeiLOBackupFile](ilo6_hpe_resourcedefns168/#hpeilobackupfile)|
 
@@ -2270,7 +2275,7 @@ The HpeiLODateTime resource describes the properties for managing the BMC data a
 
 ### Links to other Resources
 
-|Link Name|Destination type
+|Link Name|Destination type|
 |---|---|
 |`Links/EthernetNICs`|Collection of [EthernetInterface](ilo6_network_resourcedefns168/#ethernetinterfacecollection)|
 
@@ -2634,6 +2639,7 @@ Member of [HpeiLOFederationGroup.v2\_0\_0.HpeiLOFederationGroup](#hpeilofederati
 |Added|iLO6 1.05|
 
 ## HpeiLOFederationGroupCollection
+
 `@odata.type: "#HpeiLOFederationGroupCollection.HpeiLOFederationGroupCollection"`
 
 A Collection of HpeiLOFederationGroup resource instances.
@@ -2646,7 +2652,7 @@ A Collection of HpeiLOFederationGroup resource instances.
 
 ### Links to other Resources
 
-|Link Name|Destination type
+|Link Name|Destination type|
 |---|---|
 |`Members[]`|[HpeiLOFederationGroup](ilo6_hpe_resourcedefns168/#hpeilofederationgroup)|
 
@@ -2748,6 +2754,7 @@ Member of [HpeiLOFederationPeers.v2\_0\_0.HpeiLOFederationPeers](#hpeilofederati
 |Added|iLO6 1.05|
 
 ## HpeiLOFederationPeersCollection
+
 `@odata.type: "#HpeiLOFederationPeersCollection.HpeiLOFederationPeersCollection"`
 
 A Collection of HpeiLOFederationPeers resource instances.
@@ -2760,7 +2767,7 @@ A Collection of HpeiLOFederationPeers resource instances.
 
 ### Links to other Resources
 
-|Link Name|Destination type
+|Link Name|Destination type|
 |---|---|
 |`Members[]`|[HpeiLOFederationPeers](ilo6_hpe_resourcedefns168/#hpeilofederationpeers)|
 
@@ -2939,6 +2946,7 @@ Member of [HpeiLOFrus.v2\_0\_0.HpeiLOFrus](#hpeilofrus)
 |Added|iLO6 1.05|
 
 ## HpeiLOFrusCollection
+
 `@odata.type: "#HpeiLOFrusCollection.HpeiLOFrusCollection"`
 
 A Collection of HpeiLOFrus resource instances.
@@ -2952,7 +2960,7 @@ A Collection of HpeiLOFrus resource instances.
 
 ### Links to other Resources
 
-|Link Name|Destination type
+|Link Name|Destination type|
 |---|---|
 |`Members[]`|[HpeiLOFrus](ilo6_hpe_resourcedefns168/#hpeilofrus)|
 
@@ -3567,6 +3575,7 @@ Member of [HpeiLOLicense.v2\_5\_0.HpeiLOLicense](#hpeilolicense)
 |Added|iLO6 1.68|
 
 ## HpeiLOLicenseCollection
+
 `@odata.type: "#HpeiLOLicenseCollection.HpeiLOLicenseCollection"`
 
 A Collection of HpeiLOLicense resource instances.
@@ -3579,7 +3588,7 @@ A Collection of HpeiLOLicense resource instances.
 
 ### Links to other Resources
 
-|Link Name|Destination type
+|Link Name|Destination type|
 |---|---|
 |`Members[]`|[HpeiLOLicense](ilo6_hpe_resourcedefns168/#hpeilolicense)|
 
@@ -3717,7 +3726,7 @@ The HpeiLOSecurityDashboard resource describes the BMC security dashboard.
 
 ### Links to other Resources
 
-|Link Name|Destination type
+|Link Name|Destination type|
 |---|---|
 |`SecurityParameters`|[HpeiLOSecurityParam](ilo6_hpe_resourcedefns168/#hpeilosecurityparam)|
 
@@ -3862,6 +3871,7 @@ The following are the supported values:
 |`False`|The state of the Security Parameter is False.|
 
 ## HpeiLOSecurityParamCollection
+
 `@odata.type: "#HpeiLOSecurityParamCollection.HpeiLOSecurityParamCollection"`
 
 A Collection of HpeiLOSecurityParam resource instances.
@@ -3874,7 +3884,7 @@ A Collection of HpeiLOSecurityParam resource instances.
 
 ### Links to other Resources
 
-|Link Name|Destination type
+|Link Name|Destination type|
 |---|---|
 |`Members[]`|[HpeiLOSecurityParam](ilo6_hpe_resourcedefns168/#hpeilosecurityparam)|
 
@@ -3919,7 +3929,7 @@ The HpeiLOSnmpService resource describes the properties for managing the SNMP co
 
 ### Links to other Resources
 
-|Link Name|Destination type
+|Link Name|Destination type|
 |---|---|
 |`SNMPUsers`|Collection of [HpeSNMPUser](#hpesnmpuser)|
 |`SNMPAlertDestinations`|Collection of [HpeSNMPAlertDestination](ilo6_hpe_resourcedefns168/#hpesnmpalertdestinationcollection)|
@@ -4896,6 +4906,7 @@ Member of [HpeInvalidImage.v1\_0\_0.HpeInvalidImage](#hpeinvalidimage)
 |Added|iLO6 1.05|
 
 ## HpeInvalidImageCollection
+
 `@odata.type: "#HpeInvalidImageCollection.HpeInvalidImageCollection"`
 
 A Collection of HpeInvalidImage resource instances.
@@ -4908,7 +4919,7 @@ A Collection of HpeInvalidImage resource instances.
 
 ### Links to other Resources
 
-|Link Name|Destination type
+|Link Name|Destination type|
 |---|---|
 |`Members[]`|[HpeInvalidImage](ilo6_hpe_resourcedefns168/#hpeinvalidimage)|
 
@@ -4952,7 +4963,7 @@ Member of HpeInvalidImageCollection.HpeInvalidImageCollection
 
 ### Links to other Resources
 
-|Link Name|Destination type
+|Link Name|Destination type|
 |---|---|
 |`@Redfish.Settings/SettingsObject`|[HpeiSCSISoftwareInitiator](ilo6_hpe_resourcedefns168/#hpeiscsisoftwareinitiator)|
 |`Oem/Hpe/Links/BaseConfigs`|[HpeBaseConfigs](ilo6_hpe_resourcedefns168/#hpebaseconfigs)|
@@ -5280,7 +5291,7 @@ The schema definition for Key Management Service configuration.
 
 ### Links to other Resources
 
-|Link Name|Destination type
+|Link Name|Destination type|
 |---|---|
 |`settings`|[HpeKmsConfig](ilo6_hpe_resourcedefns168/#hpekmsconfig)|
 |`Oem/Hpe/Links/baseconfigs`|[HpeBaseConfigs](ilo6_hpe_resourcedefns168/#hpebaseconfigs)|
@@ -5487,6 +5498,7 @@ Member of [HpeMaintenanceWindow.v1\_0\_1.HpeMaintenanceWindow](#hpemaintenancewi
 |Format|date-time|
 
 ## HpeMaintenanceWindowCollection
+
 `@odata.type: "#HpeMaintenanceWindowCollection.HpeMaintenanceWindowCollection"`
 
 A Collection of HpeMaintenanceWindow resource instances.
@@ -5499,7 +5511,7 @@ A Collection of HpeMaintenanceWindow resource instances.
 
 ### Links to other Resources
 
-|Link Name|Destination type
+|Link Name|Destination type|
 |---|---|
 |`Members[]`|[HpeMaintenanceWindow](ilo6_hpe_resourcedefns168/#hpemaintenancewindow)|
 
@@ -5803,7 +5815,7 @@ HpeRemoteSupport enables management of HPE Remote Support configuration on iLO 5
 
 ### Links to other Resources
 
-|Link Name|Destination type
+|Link Name|Destination type|
 |---|---|
 |`ServiceEventLogs`|Collection of [LogEntry](ilo6_other_resourcedefns168/#logentrycollection)|
 
@@ -6140,6 +6152,7 @@ Member of [HpeSecureEraseReport.v1\_1\_0.HpeSecureEraseReport](#hpesecureerasere
 |Added|iLO6 1.05|
 
 ## HpeSecureEraseReportCollection
+
 `@odata.type: "#HpeSecureEraseReportCollection.HpeSecureEraseReportCollection"`
 
 A Collection of HpeSecureEraseReport resource instances.
@@ -6152,7 +6165,7 @@ A Collection of HpeSecureEraseReport resource instances.
 
 ### Links to other Resources
 
-|Link Name|Destination type
+|Link Name|Destination type|
 |---|---|
 |`Members[]`|[HpeSecureEraseReport](ilo6_hpe_resourcedefns168/#hpesecureerasereport)|
 
@@ -6197,7 +6210,7 @@ The HpeSecureEraseReportService resource describes the properties of the Secure 
 
 ### Links to other Resources
 
-|Link Name|Destination type
+|Link Name|Destination type|
 |---|---|
 |`Links/SecureEraseReportEntries`|Collection of [HpeSecureEraseReport](ilo6_hpe_resourcedefns168/#hpesecureerasereportcollection)|
 
@@ -6243,7 +6256,7 @@ The HpeSecurityService resource describes the properties for management of the s
 
 ### Links to other Resources
 
-|Link Name|Destination type
+|Link Name|Destination type|
 |---|---|
 |`SystemLDevID`|Collection of [Certificate](ilo6_other_resourcedefns168/#certificatecollection)|
 |`Links/HttpsCert`|[HpeHttpsCert](ilo6_hpe_resourcedefns168/#hpehttpscert)|
@@ -7572,7 +7585,7 @@ The schema definition of the server UEFI Boot Order resource.
 
 ### Links to other Resources
 
-|Link Name|Destination type
+|Link Name|Destination type|
 |---|---|
 |`@Redfish.Settings/SettingsObject`|[HpeServerBootSettings](ilo6_hpe_resourcedefns168/#hpeserverbootsettings)|
 |`Oem/Hpe/Links/BaseConfigs`|[HpeBaseConfigs](ilo6_hpe_resourcedefns168/#hpebaseconfigs)|
@@ -7734,7 +7747,7 @@ The schema definition for Server Configuration Lock configuration.
 
 ### Links to other Resources
 
-|Link Name|Destination type
+|Link Name|Destination type|
 |---|---|
 |`@Redfish.Settings/SettingsObject`|[HpeServerConfigLock](ilo6_hpe_resourcedefns168/#hpeserverconfiglock)|
 |`Oem/Hpe/Links/BaseConfigs`|[HpeBaseConfigs](ilo6_hpe_resourcedefns168/#hpebaseconfigs)|
@@ -8011,7 +8024,7 @@ HpeServerDevice represents physical server devices including part information.  
 
 ### Links to other Resources
 
-|Link Name|Destination type
+|Link Name|Destination type|
 |---|---|
 |`DeviceInstances[]`|[HpeServerPciDevice](ilo6_hpe_resourcedefns168/#hpeserverpcidevice)|
 
@@ -8205,6 +8218,7 @@ Member of [HpeServerDevice.v2\_1\_0.HpeServerDevice](#hpeserverdevice)
 See the Redfish standard schema and specification for information on common Status object.
 
 ## HpeServerDeviceCollection
+
 `@odata.type: "#HpeServerDeviceCollection.HpeServerDeviceCollection"`
 
 A Collection of HpeServerDevice resource instances.
@@ -8217,7 +8231,7 @@ A Collection of HpeServerDevice resource instances.
 
 ### Links to other Resources
 
-|Link Name|Destination type
+|Link Name|Destination type|
 |---|---|
 |`Members[]`|[HpeServerDevice](ilo6_hpe_resourcedefns168/#hpeserverdevice)|
 
@@ -8536,6 +8550,7 @@ Member of [HpeServerPciDevice.v2\_1\_0.HpeServerPciDevice](#hpeserverpcidevice)
 |Added|iLO6 1.05|
 
 ## HpeServerPciDeviceCollection
+
 `@odata.type: "#HpeServerPciDeviceCollection.HpeServerPciDeviceCollection"`
 
 A Collection of HpeServerPciDevice resource instances.
@@ -8548,7 +8563,7 @@ A Collection of HpeServerPciDevice resource instances.
 
 ### Links to other Resources
 
-|Link Name|Destination type
+|Link Name|Destination type|
 |---|---|
 |`Members[]`|[HpeServerPciDevice](ilo6_hpe_resourcedefns168/#hpeserverpcidevice)|
 
@@ -8837,6 +8852,7 @@ Member of [HpeServerPCISlot.v2\_2\_1.HpeServerPCISlot](#hpeserverpcislot)
 |Added|iLO6 1.05|
 
 ## HpeServerPCISlotCollection
+
 `@odata.type: "#HpeServerPCISlotCollection.HpeServerPCISlotCollection"`
 
 A Collection of HpeServerPCISlot resource instances.
@@ -8849,7 +8865,7 @@ A Collection of HpeServerPCISlot resource instances.
 
 ### Links to other Resources
 
-|Link Name|Destination type
+|Link Name|Destination type|
 |---|---|
 |`Members[]`|[HpeServerPCISlot](ilo6_hpe_resourcedefns168/#hpeserverpcislot)|
 
@@ -8954,6 +8970,7 @@ Member of [HpeSNMPAlertDestination.v2\_0\_0.HpeSNMPAlertDestination](#hpesnmpale
 |Added|iLO6 1.05|
 
 ## HpeSNMPAlertDestinationCollection
+
 `@odata.type: "#HpeSNMPAlertDestinationCollection.HpeSNMPAlertDestinationCollection"`
 
 A Collection of HpeSNMPAlertDestination resource instances.
@@ -8966,7 +8983,7 @@ A Collection of HpeSNMPAlertDestination resource instances.
 
 ### Links to other Resources
 
-|Link Name|Destination type
+|Link Name|Destination type|
 |---|---|
 |`Members[]`|[HpeSNMPAlertDestination](ilo6_hpe_resourcedefns168/#hpesnmpalertdestination)|
 
@@ -9093,6 +9110,7 @@ Member of [HpeSNMPUser.v2\_1\_1.HpeSNMPUser](#hpesnmpuser)
 |Added|iLO6 1.05|
 
 ## HpeSNMPUsersCollection
+
 `@odata.type: "#HpeSNMPUsersCollection.HpeSNMPUsersCollection"`
 
 A Collection of HpeSNMPUsers resource instances.
@@ -9105,7 +9123,7 @@ A Collection of HpeSNMPUsers resource instances.
 
 ### Links to other Resources
 
-|Link Name|Destination type
+|Link Name|Destination type|
 |---|---|
 |`Members[]`|[HpeSNMPUser](ilo6_hpe_resourcedefns168/#hpesnmpuser)|
 
@@ -9151,7 +9169,7 @@ The schema definition for TLS configuration.
 
 ### Links to other Resources
 
-|Link Name|Destination type
+|Link Name|Destination type|
 |---|---|
 |`@Redfish.Settings/SettingsObject`|[HpeTlsConfig](ilo6_hpe_resourcedefns168/#hpetlsconfig)|
 |`Oem/Hpe/Links/BaseConfigs`|[HpeBaseConfigs](ilo6_hpe_resourcedefns168/#hpebaseconfigs)|
@@ -9460,6 +9478,7 @@ Member of [HpeUSBDevice.v2\_0\_0.HpeUSBDevice](#hpeusbdevice)
 |Added|iLO6 1.05|
 
 ## HpeUSBDevicesCollection
+
 `@odata.type: "#HpeUSBDevicesCollection.HpeUSBDevicesCollection"`
 
 A Collection of HpeUSBDevices resource instances.
@@ -9472,7 +9491,7 @@ A Collection of HpeUSBDevices resource instances.
 
 ### Links to other Resources
 
-|Link Name|Destination type
+|Link Name|Destination type|
 |---|---|
 |`Members[]`|[HpeUSBDevice](ilo6_hpe_resourcedefns168/#hpeusbdevice)|
 
@@ -9645,6 +9664,7 @@ Member of [HpeUSBPort.v2\_0\_0.HpeUSBPort](#hpeusbport)
 |Added|iLO6 1.05|
 
 ## HpeUSBPortsCollection
+
 `@odata.type: "#HpeUSBPortsCollection.HpeUSBPortsCollection"`
 
 A Collection of HpeUSBPorts resource instances.
@@ -9657,7 +9677,7 @@ A Collection of HpeUSBPorts resource instances.
 
 ### Links to other Resources
 
-|Link Name|Destination type
+|Link Name|Destination type|
 |---|---|
 |`Members[]`|[HpeUSBPort](ilo6_hpe_resourcedefns168/#hpeusbport)|
 
@@ -9772,6 +9792,7 @@ The following are the supported values:
 |`High`|Utilization is high.|
 
 ## HpeWorkloadPerformanceAdvisorCollection
+
 `@odata.type: "#HpeWorkloadPerformanceAdvisorCollection.HpeWorkloadPerformanceAdvisorCollection"`
 
 A Collection of HpeWorkloadPerformanceAdvisor resource instances.
@@ -9784,7 +9805,7 @@ A Collection of HpeWorkloadPerformanceAdvisor resource instances.
 
 ### Links to other Resources
 
-|Link Name|Destination type
+|Link Name|Destination type|
 |---|---|
 |`Members[]`|[HpeWorkloadPerformanceAdvisor](ilo6_hpe_resourcedefns168/#hpeworkloadperformanceadvisor)|
 

--- a/docs/redfishServices/ilos/ilo6/ilo6_168/ilo6_manager_resourcedefns168.md
+++ b/docs/redfishServices/ilos/ilo6/ilo6_168/ilo6_manager_resourcedefns168.md
@@ -13,12 +13,12 @@ breadcrumbs:
 
 # Manager resource definitions of iLO 6 v1.68
 
-For each data type provided by the HPE ilO Redfish service, find below its description including the list of possible instances (URIs), links to related other resources, described properties and many other details. 
+For each data type provided by the HPE ilO Redfish service,find below its description including the list of possible instances (URIs),links to related other resources, described properties and many other details.
 
 Refer to the [data types and collection](/docs/concepts/dataTypesAndCollections.md) section for more information on Redfish data types and collections.
 
-
 ## ManagerCollection
+
 `@odata.type: "#ManagerCollection.ManagerCollection"`
 
 A Collection of Manager resource instances.
@@ -31,7 +31,7 @@ A Collection of Manager resource instances.
 
 ### Links to other Resources
 
-|Link Name|Destination type
+|Link Name|Destination type|
 |---|---|
 |`Members[]`|[Manager](ilo6_manager_resourcedefns168/#manager)|
 
@@ -93,7 +93,7 @@ iLO `GracefulRestart` works in the same way as `ForceRestart`.
 
 ### Links to other Resources
 
-|Link Name|Destination type
+|Link Name|Destination type|
 |---|---|
 |`SharedNetworkPorts`|Collection of [Port](ilo6_other_resourcedefns168/#portcollection)|
 |`DedicatedNetworkPorts`|Collection of [Port](ilo6_other_resourcedefns168/#portcollection)|
@@ -1942,6 +1942,7 @@ Days remaining for Air Filter change Early warning.
 
 Days remaining for Air Filter change Critical warning.
 ## ManagerAccountCollection
+
 `@odata.type: "#ManagerAccountCollection.ManagerAccountCollection"`
 
 A Collection of ManagerAccount resource instances.
@@ -1954,7 +1955,7 @@ A Collection of ManagerAccount resource instances.
 
 ### Links to other Resources
 
-|Link Name|Destination type
+|Link Name|Destination type|
 |---|---|
 |`Members[]`|[ManagerAccount](ilo6_manager_resourcedefns168/#manageraccount)|
 
@@ -1999,7 +2000,7 @@ The user accounts, owned by a Manager, are defined in this resource.  Changes to
 
 ### Links to other Resources
 
-|Link Name|Destination type
+|Link Name|Destination type|
 |---|---|
 |`Keys`|Collection of [Key](ilo6_other_resourcedefns168/#keycollection)|
 
@@ -2276,7 +2277,7 @@ iLO reset is required after the PATCH for the change to come into effect.
 
 ### Links to other Resources
 
-|Link Name|Destination type
+|Link Name|Destination type|
 |---|---|
 |`Oem/Hpe/Links/SNMPService`|[HpeiLOSnmpService](ilo6_hpe_resourcedefns168/#hpeilosnmpservice)|
 |`Oem/Hpe/Links/EthernetInterfaces`|Collection of [EthernetInterface](ilo6_network_resourcedefns168/#ethernetinterfacecollection)|

--- a/docs/redfishServices/ilos/ilo6/ilo6_168/ilo6_network_resourcedefns168.md
+++ b/docs/redfishServices/ilos/ilo6/ilo6_168/ilo6_network_resourcedefns168.md
@@ -13,12 +13,12 @@ breadcrumbs:
 
 # Network resource definitions of iLO 6 v1.68
 
-For each data type provided by the HPE ilO Redfish service, find below its description including the list of possible instances (URIs), links to related other resources, described properties and many other details. 
+For each data type provided by the HPE ilO Redfish service,find below its description including the list of possible instances (URIs),links to related other resources, described properties and many other details.
 
 Refer to the [data types and collection](/docs/concepts/dataTypesAndCollections.md) section for more information on Redfish data types and collections.
 
-
 ## NetworkAdapterCollection
+
 `@odata.type: "#NetworkAdapterCollection.NetworkAdapterCollection"`
 
 A Collection of NetworkAdapter resource instances.
@@ -31,7 +31,7 @@ A Collection of NetworkAdapter resource instances.
 
 ### Links to other Resources
 
-|Link Name|Destination type
+|Link Name|Destination type|
 |---|---|
 |`Members[]`|[NetworkAdapter](ilo6_network_resourcedefns168/#networkadapter)|
 
@@ -99,7 +99,7 @@ The Data Source is either DCi or RDE. HPE OEM section shall be present only for 
 
 ### Links to other Resources
 
-|Link Name|Destination type
+|Link Name|Destination type|
 |---|---|
 |`ports`|Collection of [Port](ilo6_other_resourcedefns168/#portcollection)|
 |`assembly`|[Assembly](ilo6_other_resourcedefns168/#assembly)|
@@ -1340,6 +1340,7 @@ There are no parameters for this action.
 Member of [NetworkAdapter.v1\_11\_0.NetworkAdapter](#networkadapter)
 There are no parameters for this action.
 ## NetworkDeviceFunctionCollection
+
 `@odata.type: "#NetworkDeviceFunctionCollection.NetworkDeviceFunctionCollection"`
 
 A Collection of NetworkDeviceFunction resource instances.
@@ -1353,7 +1354,7 @@ A Collection of NetworkDeviceFunction resource instances.
 
 ### Links to other Resources
 
-|Link Name|Destination type
+|Link Name|Destination type|
 |---|---|
 |`Members[]`|[NetworkDeviceFunction](ilo6_network_resourcedefns168/#networkdevicefunction)|
 
@@ -1404,7 +1405,7 @@ The Data Source is either DCi or RDE. HPE OEM section shall be present only for 
 
 ### Links to other Resources
 
-|Link Name|Destination type
+|Link Name|Destination type|
 |---|---|
 |`settings`|[NetworkDeviceFunction](ilo6_network_resourcedefns168/#networkdevicefunction)|
 
@@ -2111,6 +2112,7 @@ Member of [NetworkDeviceFunction.v1\_8\_0.NetworkDeviceFunction](#networkdevicef
 |Added|iLO6 1.05|
 
 ## NetworkInterfaceCollection
+
 `@odata.type: "#NetworkInterfaceCollection.NetworkInterfaceCollection"`
 
 A Collection of NetworkInterface resource instances.
@@ -2123,7 +2125,7 @@ A Collection of NetworkInterface resource instances.
 
 ### Links to other Resources
 
-|Link Name|Destination type
+|Link Name|Destination type|
 |---|---|
 |`Members[]`|[NetworkInterface](ilo6_network_resourcedefns168/#networkinterface)|
 
@@ -2187,7 +2189,7 @@ A NetworkInterface contains references linking NetworkAdapter, Port, and Network
 
 ### Links to other Resources
 
-|Link Name|Destination type
+|Link Name|Destination type|
 |---|---|
 |`NetworkDeviceFunctions`|Collection of [NetworkDeviceFunction](ilo6_network_resourcedefns168/#networkdevicefunctioncollection)|
 
@@ -2207,6 +2209,7 @@ Member of [NetworkInterface.v1\_2\_0.NetworkInterface](#networkinterface)
 See the Redfish standard schema and specification for information on common Status object.
 
 ## EthernetInterfaceCollection
+
 `@odata.type: "#EthernetInterfaceCollection.EthernetInterfaceCollection"`
 
 A Collection of EthernetInterface resource instances.
@@ -2220,7 +2223,7 @@ A Collection of EthernetInterface resource instances.
 
 ### Links to other Resources
 
-|Link Name|Destination type
+|Link Name|Destination type|
 |---|---|
 |`Members[]`|[EthernetInterface](ilo6_network_resourcedefns168/#ethernetinterface)|
 

--- a/docs/redfishServices/ilos/ilo6/ilo6_168/ilo6_other_resourcedefns168.md
+++ b/docs/redfishServices/ilos/ilo6/ilo6_168/ilo6_other_resourcedefns168.md
@@ -13,10 +13,9 @@ breadcrumbs:
 
 # Other resource definitions of iLO 6 v1.68
 
-For each data type provided by the HPE ilO Redfish service, find below its description including the list of possible instances (URIs), links to related other resources, described properties and many other details. 
+For each data type provided by the HPE ilO Redfish service,find below its description including the list of possible instances (URIs),links to related other resources, described properties and many other details.
 
 Refer to the [data types and collection](/docs/concepts/dataTypesAndCollections.md) section for more information on Redfish data types and collections.
-
 
 ## AccountService
 
@@ -47,7 +46,7 @@ The destination of this link is a collection of user accounts (see ManagerAccoun
 
 ### Links to other Resources
 
-|Link Name|Destination type
+|Link Name|Destination type|
 |---|---|
 |`Accounts`|Collection of [ManagerAccount](ilo6_manager_resourcedefns168/#manageraccountcollection)|
 
@@ -812,6 +811,7 @@ Member of [BootOption.v1\_0\_1.BootOption](#bootoption)
 
 
 ## BootOptionCollection
+
 `@odata.type: "#BootOptionCollection.BootOptionCollection"`
 
 A Collection of BootOption resource instances.
@@ -824,7 +824,7 @@ A Collection of BootOption resource instances.
 
 ### Links to other Resources
 
-|Link Name|Destination type
+|Link Name|Destination type|
 |---|---|
 |`Members[]`|[BootOption](ilo6_other_resourcedefns168/#bootoption)|
 
@@ -1133,6 +1133,7 @@ Member of [Certificate.v1\_6\_0.Certificate](#certificate)
 
 
 ## CertificateCollection
+
 `@odata.type: "#CertificateCollection.CertificateCollection"`
 
 A Collection of Certificate resource instances.
@@ -1169,7 +1170,7 @@ A Collection of Certificate resource instances.
 
 ### Links to other Resources
 
-|Link Name|Destination type
+|Link Name|Destination type|
 |---|---|
 |`Members[]`|[Certificate](ilo6_other_resourcedefns168/#certificate)|
 
@@ -1228,7 +1229,7 @@ The CertificateService schema describes a certificate service that represents th
 
 ### Links to other Resources
 
-|Link Name|Destination type
+|Link Name|Destination type|
 |---|---|
 |`Links/CertificateLocations`|[CertificateLocations](ilo6_other_resourcedefns168/#certificatelocations)|
 
@@ -1700,6 +1701,7 @@ The slot identifier for the certificate containing the private key to generate t
 An array of indices that identify the measurement blocks to sign.
 
 ## ComponentIntegrityCollection
+
 `@odata.type: "#ComponentIntegrityCollection.ComponentIntegrityCollection"`
 
 A Collection of ComponentIntegrity resource instances.
@@ -1712,7 +1714,7 @@ A Collection of ComponentIntegrity resource instances.
 
 ### Links to other Resources
 
-|Link Name|Destination type
+|Link Name|Destination type|
 |---|---|
 |`Members[]`|[ComponentIntegrity](ilo6_other_resourcedefns168/#componentintegrity)|
 
@@ -2029,6 +2031,7 @@ The following are the supported values:
 
 
 ## EventDestinationCollection
+
 `@odata.type: "#EventDestinationCollection.EventDestinationCollection"`
 
 A Collection of EventDestination resource instances.
@@ -2041,7 +2044,7 @@ A Collection of EventDestination resource instances.
 
 ### Links to other Resources
 
-|Link Name|Destination type
+|Link Name|Destination type|
 |---|---|
 |`Members[]`|[EventDestination](ilo6_other_resourcedefns168/#eventdestination)|
 
@@ -2087,7 +2090,7 @@ The EventService resource describes the Event Service.  It represents the proper
 
 ### Links to other Resources
 
-|Link Name|Destination type
+|Link Name|Destination type|
 |---|---|
 |`Subscriptions`|Collection of [EventDestination](ilo6_other_resourcedefns168/#eventdestinationcollection)|
 |`Oem/Hpe/CACertificates`|Collection of [HpeCertificate](ilo6_hpe_resourcedefns168/#hpecertificatecollection)|
@@ -2295,7 +2298,7 @@ The Fabric schema represents a simple fabric consisting of one or more switches,
 
 ### Links to other Resources
 
-|Link Name|Destination type
+|Link Name|Destination type|
 |---|---|
 |`switches`|Collection of [SwitchCollection](#switchcollection-switchcollection)|
 
@@ -2359,6 +2362,7 @@ Switches is a link (`"@odata.id": URI`) to another resource.
 
 
 ## FabricCollection
+
 `@odata.type: "#FabricCollection.FabricCollection"`
 
 A Collection of Fabric Resource instances.
@@ -2371,7 +2375,7 @@ A Collection of Fabric Resource instances.
 
 ### Links to other Resources
 
-|Link Name|Destination type
+|Link Name|Destination type|
 |---|---|
 |`Members[]`|[Fabric](ilo6_other_resourcedefns168/#fabric)|
 
@@ -2417,7 +2421,7 @@ The Fan schema describes a cooling fan unit for a computer system or similar dev
 
 ### Links to other Resources
 
-|Link Name|Destination type
+|Link Name|Destination type|
 |---|---|
 |`assembly`|[Assembly](ilo6_other_resourcedefns168/#assembly)|
 
@@ -2513,6 +2517,7 @@ See the Redfish standard schema and specification for information on common Stat
 
 
 ## FanCollection
+
 `@odata.type: "#FanCollection.FanCollection"`
 
 The Collection of Fan resource instances.
@@ -2525,7 +2530,7 @@ The Collection of Fan resource instances.
 
 ### Links to other Resources
 
-|Link Name|Destination type
+|Link Name|Destination type|
 |---|---|
 |`Members[]`|[Fan](ilo6_other_resourcedefns168/#fan)|
 
@@ -2703,6 +2708,7 @@ See the Redfish standard schema and specification for information on common Stat
 
 
 ## HostInterfaceCollection
+
 `@odata.type: "#HostInterfaceCollection.HostInterfaceCollection"`
 
 A Collection of HostInterface resource instances.
@@ -2715,7 +2721,7 @@ A Collection of HostInterface resource instances.
 
 ### Links to other Resources
 
-|Link Name|Destination type
+|Link Name|Destination type|
 |---|---|
 |`Members[]`|[HostInterface](ilo6_other_resourcedefns168/#hostinterface)|
 
@@ -2814,6 +2820,7 @@ Member of [JsonSchemaFile.v1\_0\_4.JsonSchemaFile](#jsonschemafile)
 
 
 ## JsonSchemaFileCollection
+
 `@odata.type: "#JsonSchemaFileCollection.JsonSchemaFileCollection"`
 
 A Collection of JsonSchemaFile resource instances.
@@ -2826,7 +2833,7 @@ A Collection of JsonSchemaFile resource instances.
 
 ### Links to other Resources
 
-|Link Name|Destination type
+|Link Name|Destination type|
 |---|---|
 |`Members[]`|[JsonSchemaFile](ilo6_other_resourcedefns168/#jsonschemafile)|
 
@@ -2922,6 +2929,7 @@ Member of [Key.v1\_4\_1.Key](#key)
 
 
 ## KeyCollection
+
 `@odata.type: "#KeyCollection.KeyCollection"`
 
 The collection of `Key` resource instances.
@@ -2934,7 +2942,7 @@ The collection of `Key` resource instances.
 
 ### Links to other Resources
 
-|Link Name|Destination type
+|Link Name|Destination type|
 |---|---|
 |`Members[]`|[Key](ilo6_other_resourcedefns168/#key)|
 
@@ -3339,6 +3347,7 @@ The following are the supported values:
 
 
 ## LogEntryCollection
+
 `@odata.type: "#LogEntryCollection.LogEntryCollection"`
 
 A Collection of LogEntry resource instances.
@@ -3356,7 +3365,7 @@ A Collection of LogEntry resource instances.
 
 ### Links to other Resources
 
-|Link Name|Destination type
+|Link Name|Destination type|
 |---|---|
 |`Members[]`|[LogEntry](ilo6_other_resourcedefns168/#logentry)|
 
@@ -3767,7 +3776,7 @@ This resource contains properties for monitoring and configuring an event log se
 
 ### Links to other Resources
 
-|Link Name|Destination type
+|Link Name|Destination type|
 |---|---|
 |`Entries`|Collection of [LogEntry](ilo6_other_resourcedefns168/#logentrycollection)|
 
@@ -3853,6 +3862,7 @@ Member of [LogService.v1\_1\_0.LogService](#logservice)
 There are no parameters for this action.
 
 ## LogServiceCollection
+
 `@odata.type: "#LogServiceCollection.LogServiceCollection"`
 
 A Collection of LogService resource instances.
@@ -3866,7 +3876,7 @@ A Collection of LogService resource instances.
 
 ### Links to other Resources
 
-|Link Name|Destination type
+|Link Name|Destination type|
 |---|---|
 |`Members[]`|[LogService](ilo6_other_resourcedefns168/#logservice)|
 
@@ -3912,7 +3922,7 @@ The Memory resource describes a memory module.
 
 ### Links to other Resources
 
-|Link Name|Destination type
+|Link Name|Destination type|
 |---|---|
 |`memorymetrics`|[MemoryMetrics](ilo6_other_resourcedefns168/#memorymetrics)|
 
@@ -4981,6 +4991,7 @@ See the Redfish standard schema and specification for information on common Stat
 
 
 ## MemoryChunksCollection
+
 `@odata.type: "#MemoryChunksCollection.MemoryChunksCollection"`
 
 A Collection of MemoryChunks resource instances.
@@ -4993,7 +5004,7 @@ A Collection of MemoryChunks resource instances.
 
 ### Links to other Resources
 
-|Link Name|Destination type
+|Link Name|Destination type|
 |---|---|
 |`Members[]`|[MemoryChunks](ilo6_other_resourcedefns168/#memorychunks)|
 
@@ -5026,6 +5037,7 @@ Member of MemoryChunksCollection.MemoryChunksCollection
 
 
 ## MemoryCollection
+
 `@odata.type: "#MemoryCollection.MemoryCollection"`
 
 A Collection of Memory resource instances.
@@ -5038,7 +5050,7 @@ A Collection of Memory resource instances.
 
 ### Links to other Resources
 
-|Link Name|Destination type
+|Link Name|Destination type|
 |---|---|
 |`Members[]`|[Memory](ilo6_other_resourcedefns168/#memory)|
 
@@ -5322,6 +5334,7 @@ MemoryChunks is a link (`"@odata.id": URI`) to another resource.
 
 
 ## MemoryDomainCollection
+
 `@odata.type: "#MemoryDomainCollection.MemoryDomainCollection"`
 
 A Collection of MemoryDomain resource instances.
@@ -5334,7 +5347,7 @@ A Collection of MemoryDomain resource instances.
 
 ### Links to other Resources
 
-|Link Name|Destination type
+|Link Name|Destination type|
 |---|---|
 |`Members[]`|[MemoryDomain](ilo6_other_resourcedefns168/#memorydomain)|
 
@@ -5468,6 +5481,7 @@ Member of [MessageRegistryFile.v1\_0\_4.MessageRegistryFile](#messageregistryfil
 
 
 ## MessageRegistryFileCollection
+
 `@odata.type: "#MessageRegistryFileCollection.MessageRegistryFileCollection"`
 
 A Collection of MessageRegistryFile resource instances.
@@ -5480,7 +5494,7 @@ A Collection of MessageRegistryFile resource instances.
 
 ### Links to other Resources
 
-|Link Name|Destination type
+|Link Name|Destination type|
 |---|---|
 |`Members[]`|[MessageRegistryFile](ilo6_other_resourcedefns168/#messageregistryfile)|
 
@@ -5686,6 +5700,7 @@ Member of [MetricDefinition.v1\_0\_0.MetricDefinition](#metricdefinition)
 
 
 ## MetricDefinitionCollection
+
 `@odata.type: "#MetricDefinitionCollection.MetricDefinitionCollection"`
 
 A Collection of MetricDefinition resource instances.
@@ -5698,7 +5713,7 @@ A Collection of MetricDefinition resource instances.
 
 ### Links to other Resources
 
-|Link Name|Destination type
+|Link Name|Destination type|
 |---|---|
 |`Members[]`|[MetricDefinition](ilo6_other_resourcedefns168/#metricdefinition)|
 
@@ -5790,6 +5805,7 @@ Member of [MetricReport.v1\_0\_0.MetricReport](#metricreport)
 
 
 ## MetricReportCollection
+
 `@odata.type: "#MetricReportCollection.MetricReportCollection"`
 
 A Collection of MetricReport resource instances.
@@ -5802,7 +5818,7 @@ A Collection of MetricReport resource instances.
 
 ### Links to other Resources
 
-|Link Name|Destination type
+|Link Name|Destination type|
 |---|---|
 |`Members[]`|[MetricReport](ilo6_other_resourcedefns168/#metricreport)|
 
@@ -6006,6 +6022,7 @@ See the Redfish standard schema and specification for information on common Stat
 
 
 ## MetricReportDefinitionCollection
+
 `@odata.type: "#MetricReportDefinitionCollection.MetricReportDefinitionCollection"`
 
 A Collection of MetricReportDefinition resource instances.
@@ -6018,7 +6035,7 @@ A Collection of MetricReportDefinition resource instances.
 
 ### Links to other Resources
 
-|Link Name|Destination type
+|Link Name|Destination type|
 |---|---|
 |`Members[]`|[MetricReportDefinition](ilo6_other_resourcedefns168/#metricreportdefinition)|
 
@@ -6064,7 +6081,7 @@ This is the schema definition for the PCIeDevice resource.  It represents the pr
 
 ### Links to other Resources
 
-|Link Name|Destination type
+|Link Name|Destination type|
 |---|---|
 |`PCIeFunctions`|[PCIeFunction](ilo6_other_resourcedefns168/#pciefunction)|
 
@@ -6264,6 +6281,7 @@ See the Redfish standard schema and specification for information on common Stat
 
 
 ## PCIeDeviceCollection
+
 `@odata.type: "#PCIeDeviceCollection.PCIeDeviceCollection"`
 
 The collection of PCIeDevice Resource instances.
@@ -6276,7 +6294,7 @@ The collection of PCIeDevice Resource instances.
 
 ### Links to other Resources
 
-|Link Name|Destination type
+|Link Name|Destination type|
 |---|---|
 |`Members[]`|[PCIeDevice](ilo6_other_resourcedefns168/#pciedevice)|
 
@@ -6461,6 +6479,7 @@ Member of [PCIeFunction.v1\_2\_3.PCIeFunction](#pciefunction)
 
 
 ## PCIeFunctionCollection
+
 `@odata.type: "#PCIeFunctionCollection.PCIeFunctionCollection"`
 
 The collection of PCIeFunction Resource instances.
@@ -6473,7 +6492,7 @@ The collection of PCIeFunction Resource instances.
 
 ### Links to other Resources
 
-|Link Name|Destination type
+|Link Name|Destination type|
 |---|---|
 |`Members[]`|[PCIeFunction](ilo6_other_resourcedefns168/#pciefunction)|
 
@@ -6764,7 +6783,7 @@ The Data Source is either DCi or RDE. HPE OEM section shall be present only for 
 
 ### Links to other Resources
 
-|Link Name|Destination type
+|Link Name|Destination type|
 |---|---|
 |`settings`|[Port](ilo6_other_resourcedefns168/#port)|
 |`portmetrics`|[PortMetrics](ilo6_other_resourcedefns168/#portmetrics)|
@@ -9014,6 +9033,7 @@ Reset Port
 |Nmi|Generate a diagnostic interrupt, which is usually an NMI on x86 systems, to stop normal operations, complete diagnostic actions, and, typically, halt the system.|
 
 ## PortCollection
+
 `@odata.type: "#PortCollection.PortCollection"`
 
 A Collection of Port resource instances.
@@ -9032,7 +9052,7 @@ A Collection of Port resource instances.
 
 ### Links to other Resources
 
-|Link Name|Destination type
+|Link Name|Destination type|
 |---|---|
 |`Members[]`|[Port](ilo6_other_resourcedefns168/#port)|
 
@@ -9103,7 +9123,7 @@ The Power resource describes the Power Metrics.  It represents the properties fo
 
 ### Links to other Resources
 
-|Link Name|Destination type
+|Link Name|Destination type|
 |---|---|
 |`Oem/Hpe/Links/FederatedGroupCapping`|[HpeiLOFederatedGroupCapping](ilo6_hpe_resourcedefns168/#hpeilofederatedgroupcapping)|
 |`Oem/Hpe/Links/PowerMeter`|[HpePowerMeter](ilo6_hpe_resourcedefns168/#hpepowermeter)|
@@ -10472,7 +10492,7 @@ The Processor resource describes the Processor resource.  It represents the prop
 
 ### Links to other Resources
 
-|Link Name|Destination type
+|Link Name|Destination type|
 |---|---|
 |`environmentmetrics`|[EnvironmentMetrics](ilo6_other_resourcedefns168/#environmentmetrics)|
 |`processormetrics`|[ProcessorMetrics](ilo6_other_resourcedefns168/#processormetrics)|
@@ -11119,6 +11139,7 @@ Member of [Processor.v1\_8\_2.Processor](#processor)
 
 
 ## ProcessorCollection
+
 `@odata.type: "#ProcessorCollection.ProcessorCollection"`
 
 A Collection of Processor resource instances.
@@ -11131,7 +11152,7 @@ A Collection of Processor resource instances.
 
 ### Links to other Resources
 
-|Link Name|Destination type
+|Link Name|Destination type|
 |---|---|
 |`Members[]`|[Processor](ilo6_other_resourcedefns168/#processor)|
 
@@ -11290,7 +11311,7 @@ The Pump schema describes a pump unit for a cooling system or similar device.
 
 ### Links to other Resources
 
-|Link Name|Destination type
+|Link Name|Destination type|
 |---|---|
 |`Assembly`|[Assembly](ilo6_other_resourcedefns168/#assembly)|
 
@@ -11375,6 +11396,7 @@ See the Redfish standard schema and specification for information on common Stat
 
 
 ## PumpCollection
+
 `@odata.type: "#PumpCollection.PumpCollection"`
 
 The collection of Pump resource instances.
@@ -11387,7 +11409,7 @@ The collection of Pump resource instances.
 
 ### Links to other Resources
 
-|Link Name|Destination type
+|Link Name|Destination type|
 |---|---|
 |`Members[]`|[Pump](ilo6_other_resourcedefns168/#pump)|
 
@@ -11529,6 +11551,7 @@ Member of [Role.v1\_2\_1.Role](#role)
 
 
 ## RoleCollection
+
 `@odata.type: "#RoleCollection.RoleCollection"`
 
 A Collection of Role resource instances.
@@ -11541,7 +11564,7 @@ A Collection of Role resource instances.
 
 ### Links to other Resources
 
-|Link Name|Destination type
+|Link Name|Destination type|
 |---|---|
 |`Members[]`|[Role](ilo6_other_resourcedefns168/#role)|
 
@@ -11587,7 +11610,7 @@ This resource contains UEFI Secure Boot information. It represents properties fo
 
 ### Links to other Resources
 
-|Link Name|Destination type
+|Link Name|Destination type|
 |---|---|
 |`securebootdatabases`|Collection of [SecureBootDatabase](ilo6_other_resourcedefns168/#securebootdatabasecollection)|
 
@@ -11690,7 +11713,7 @@ The SecureBootDatabase schema describes a UEFI Secure Boot database used to stor
 
 ### Links to other Resources
 
-|Link Name|Destination type
+|Link Name|Destination type|
 |---|---|
 |`Certificates`|Collection of [Certificate](ilo6_other_resourcedefns168/#certificatecollection)|
 |`Signatures`|Collection of [Signature](ilo6_other_resourcedefns168/#signaturecollection)|
@@ -11736,6 +11759,7 @@ This parameter specifies what type of reset action to perform.
 |DeleteAllKeys|Delete all Secure Boot Database keys on next boot.|
 
 ## SecureBootDatabaseCollection
+
 `@odata.type: "#SecureBootDatabaseCollection.SecureBootDatabaseCollection"`
 
 The collection of SecureBootDatabase resource instances.
@@ -11748,7 +11772,7 @@ The collection of SecureBootDatabase resource instances.
 
 ### Links to other Resources
 
-|Link Name|Destination type
+|Link Name|Destination type|
 |---|---|
 |`Members[]`|[SecureBootDatabase](ilo6_other_resourcedefns168/#securebootdatabase)|
 
@@ -12139,6 +12163,7 @@ Member of [Sensor.v1\_10\_0.Sensor](#sensor)
 
 
 ## SensorCollection
+
 `@odata.type: "#SensorCollection.SensorCollection"`
 
 The collection of Sensor resource instances.
@@ -12151,7 +12176,7 @@ The collection of Sensor resource instances.
 
 ### Links to other Resources
 
-|Link Name|Destination type
+|Link Name|Destination type|
 |---|---|
 |`Members[]`|[Sensor](ilo6_other_resourcedefns168/#sensor)|
 
@@ -12229,6 +12254,7 @@ Member of [SerialInterface.v1\_1\_7.SerialInterface](#serialinterface)
 
 
 ## SerialInterfaceCollection
+
 `@odata.type: "#SerialInterfaceCollection.SerialInterfaceCollection"`
 
 A Collection of SerialInterface resource instances.
@@ -12241,7 +12267,7 @@ A Collection of SerialInterface resource instances.
 
 ### Links to other Resources
 
-|Link Name|Destination type
+|Link Name|Destination type|
 |---|---|
 |`Members[]`|[SerialInterface](ilo6_other_resourcedefns168/#serialinterface)|
 
@@ -12535,6 +12561,7 @@ Member of [Session.v1\_0\_0.Session](#session)
 
 
 ## SessionCollection
+
 `@odata.type: "#SessionCollection.SessionCollection"`
 
 A Collection of Session resource instances.
@@ -12547,7 +12574,7 @@ A Collection of Session resource instances.
 
 ### Links to other Resources
 
-|Link Name|Destination type
+|Link Name|Destination type|
 |---|---|
 |`Oem/Hpe/Links/MySession`|[Session](ilo6_other_resourcedefns168/#session)|
 |`Members[]`|[Session](ilo6_other_resourcedefns168/#session)|
@@ -12594,7 +12621,7 @@ The SessionService resource describes the BMC Redfish Session Service.  It repre
 
 ### Links to other Resources
 
-|Link Name|Destination type
+|Link Name|Destination type|
 |---|---|
 |`Sessions`|Collection of [Session](ilo6_other_resourcedefns168/#sessioncollection)|
 
@@ -12701,6 +12728,7 @@ Member of [Signature.v1\_0\_2.Signature](#signature)
 
 
 ## SignatureCollection
+
 `@odata.type: "#SignatureCollection.SignatureCollection"`
 
 The collection of Signature resource instances.
@@ -12720,7 +12748,7 @@ The collection of Signature resource instances.
 
 ### Links to other Resources
 
-|Link Name|Destination type
+|Link Name|Destination type|
 |---|---|
 |`Members[]`|[Signature](ilo6_other_resourcedefns168/#signature)|
 
@@ -12914,6 +12942,7 @@ Member of [SoftwareInventory.v1\_2\_0.SoftwareInventory](#softwareinventory)
 
 
 ## SoftwareInventoryCollection
+
 `@odata.type: "#SoftwareInventoryCollection.SoftwareInventoryCollection"`
 
 A Collection of SoftwareInventory resource instances.
@@ -12927,7 +12956,7 @@ A Collection of SoftwareInventory resource instances.
 
 ### Links to other Resources
 
-|Link Name|Destination type
+|Link Name|Destination type|
 |---|---|
 |`Members[]`|[SoftwareInventory](ilo6_other_resourcedefns168/#softwareinventory)|
 
@@ -12973,7 +13002,7 @@ The Switch schema contains properties that describe a fabric switch.
 
 ### Links to other Resources
 
-|Link Name|Destination type
+|Link Name|Destination type|
 |---|---|
 |`ports`|Collection of [Port](ilo6_other_resourcedefns168/#portcollection)|
 
@@ -13108,6 +13137,7 @@ Member of [Switch.v1\_9\_1.Switch](#switch)
 
 
 ## SwitchCollection
+
 `@odata.type: "#SwitchCollection.SwitchCollection"`
 
 A Collection of Switch Resource instances.
@@ -13120,7 +13150,7 @@ A Collection of Switch Resource instances.
 
 ### Links to other Resources
 
-|Link Name|Destination type
+|Link Name|Destination type|
 |---|---|
 |`Members[]`|Collection of [SwitchCollection](#switchcollection-switchcollection)|
 
@@ -13377,6 +13407,7 @@ The following are the supported values:
 
 
 ## TaskCollection
+
 `@odata.type: "#TaskCollection.TaskCollection"`
 
 A Collection of Task resource instances.
@@ -13389,7 +13420,7 @@ A Collection of Task resource instances.
 
 ### Links to other Resources
 
-|Link Name|Destination type
+|Link Name|Destination type|
 |---|---|
 |`Members[]`|[Task](ilo6_other_resourcedefns168/#task)|
 
@@ -13435,7 +13466,7 @@ The TaskService resource describes the Task service. It represents the propertie
 
 ### Links to other Resources
 
-|Link Name|Destination type
+|Link Name|Destination type|
 |---|---|
 |`Tasks`|Collection of [Task](ilo6_other_resourcedefns168/#taskcollection)|
 
@@ -13521,7 +13552,7 @@ Telemetry Service is supported only on Intel platform. On AMD systems, performin
 
 ### Links to other Resources
 
-|Link Name|Destination type
+|Link Name|Destination type|
 |---|---|
 |`MetricReports`|Collection of [MetricReport](ilo6_other_resourcedefns168/#metricreportcollection)|
 |`MetricReportDefinitions`|Collection of [MetricDefinition](ilo6_other_resourcedefns168/#metricdefinitioncollection)|
@@ -14335,7 +14366,7 @@ This ThermalSubsystem schema contains the definition for the thermal subsystem o
 
 ### Links to other Resources
 
-|Link Name|Destination type
+|Link Name|Destination type|
 |---|---|
 |`Fans`|Collection of [Fan](ilo6_other_resourcedefns168/#fancollection)|
 
@@ -14641,6 +14672,7 @@ The following are the supported values:
 
 
 ## TriggersCollection
+
 `@odata.type: "#TriggersCollection.TriggersCollection"`
 
 A Collection of Triggers resource instances.
@@ -14653,7 +14685,7 @@ A Collection of Triggers resource instances.
 
 ### Links to other Resources
 
-|Link Name|Destination type
+|Link Name|Destination type|
 |---|---|
 |`Members[]`|[Triggers](ilo6_other_resourcedefns168/#triggers)|
 
@@ -14699,7 +14731,7 @@ The UpdateService resource describes the Update Service. It represents the prope
 
 ### Links to other Resources
 
-|Link Name|Destination type
+|Link Name|Destination type|
 |---|---|
 |`Oem/Hpe/InstallSets`|Collection of [HpeComponentInstallSet](ilo6_hpe_resourcedefns168/#hpecomponentinstallsetcollection)|
 |`Oem/Hpe/ComponentRepository`|Collection of [HpeComponent](ilo6_hpe_resourcedefns168/#hpecomponentcollection)|
@@ -15320,6 +15352,7 @@ A text description of the reason for this action invocation.
 A RSA2048 SHA-256 signature validating the provided Intent (Base64 encoded).
 
 ## VirtualMediaCollection
+
 `@odata.type: "#VirtualMediaCollection.VirtualMediaCollection"`
 
 A Collection of VirtualMedia resource instances.
@@ -15332,7 +15365,7 @@ A Collection of VirtualMedia resource instances.
 
 ### Links to other Resources
 
-|Link Name|Destination type
+|Link Name|Destination type|
 |---|---|
 |`Members[]`|[VirtualMedia](ilo6_other_resourcedefns168/#virtualmedia)|
 

--- a/docs/redfishServices/ilos/ilo6/ilo6_168/ilo6_serviceroot_resourcedefns168.md
+++ b/docs/redfishServices/ilos/ilo6/ilo6_168/ilo6_serviceroot_resourcedefns168.md
@@ -13,10 +13,9 @@ breadcrumbs:
 
 # Serviceroot resource definitions of iLO 6 v1.68
 
-For each data type provided by the HPE ilO Redfish service, find below its description including the list of possible instances (URIs), links to related other resources, described properties and many other details. 
+For each data type provided by the HPE ilO Redfish service,find below its description including the list of possible instances (URIs),links to related other resources, described properties and many other details.
 
 Refer to the [data types and collection](/docs/concepts/dataTypesAndCollections.md) section for more information on Redfish data types and collections.
-
 
 ## ServiceRoot
 
@@ -32,7 +31,7 @@ The ServiceRoot resource describes the Redfish API service root.
 
 ### Links to other Resources
 
-|Link Name|Destination type
+|Link Name|Destination type|
 |---|---|
 |`Registries`|Collection of [MessageRegistryFile](ilo6_other_resourcedefns168/#messageregistryfilecollection)|
 |`Systems`|Collection of [ComputerSystem](ilo6_computersystem_resourcedefns168/#computersystemcollection)|

--- a/docs/redfishServices/ilos/ilo6/ilo6_168/ilo6_storage_resourcedefns168.md
+++ b/docs/redfishServices/ilos/ilo6/ilo6_168/ilo6_storage_resourcedefns168.md
@@ -13,12 +13,12 @@ breadcrumbs:
 
 # Storage resource definitions of iLO 6 v1.68
 
-For each data type provided by the HPE ilO Redfish service, find below its description including the list of possible instances (URIs), links to related other resources, described properties and many other details. 
+For each data type provided by the HPE ilO Redfish service,find below its description including the list of possible instances (URIs),links to related other resources, described properties and many other details.
 
 Refer to the [data types and collection](/docs/concepts/dataTypesAndCollections.md) section for more information on Redfish data types and collections.
 
-
 ## StorageCollection
+
 `@odata.type: "#StorageCollection.StorageCollection"`
 
 A Collection of Storage resource instances.
@@ -31,7 +31,7 @@ A Collection of Storage resource instances.
 
 ### Links to other Resources
 
-|Link Name|Destination type
+|Link Name|Destination type|
 |---|---|
 |`Members[]`|[Storage](ilo6_storage_resourcedefns168/#storage)|
 
@@ -76,7 +76,7 @@ Storage defines a storage subsystem and its respective properties.  A storage su
 
 ### Links to other Resources
 
-|Link Name|Destination type
+|Link Name|Destination type|
 |---|---|
 |`Volumes`|Collection of [Volume](ilo6_storage_resourcedefns168/#volumecollection)|
 |`Controllers`|Collection of [StorageController](ilo6_storage_resourcedefns168/#storagecontrollercollection)|
@@ -631,6 +631,7 @@ Link to invoke action
 
 Friendly action name
 ## StorageControllerCollection
+
 `@odata.type: "#StorageControllerCollection.StorageControllerCollection"`
 
 A Collection of Storage resource instances.
@@ -643,7 +644,7 @@ A Collection of Storage resource instances.
 
 ### Links to other Resources
 
-|Link Name|Destination type
+|Link Name|Destination type|
 |---|---|
 |`Members[]`|[StorageController](ilo6_storage_resourcedefns168/#storagecontroller)|
 
@@ -688,7 +689,7 @@ The StorageController schema describes a storage controller and its properties. 
 
 ### Links to other Resources
 
-|Link Name|Destination type
+|Link Name|Destination type|
 |---|---|
 |`certificates`|Collection of [Certificate](ilo6_other_resourcedefns168/#certificatecollection)|
 |`ports`|Collection of [Port](ilo6_other_resourcedefns168/#portcollection)|
@@ -1185,6 +1186,7 @@ The following are the supported values:
 |`None`|A placement policy with no redundancy at the device level.|
 
 ## VolumeCollection
+
 `@odata.type: "#VolumeCollection.VolumeCollection"`
 
 A Collection of Volume resource instances.
@@ -1197,7 +1199,7 @@ A Collection of Volume resource instances.
 
 ### Links to other Resources
 
-|Link Name|Destination type
+|Link Name|Destination type|
 |---|---|
 |`Members[]`|[Volume](ilo6_storage_resourcedefns168/#volume)|
 
@@ -1241,7 +1243,7 @@ The Volume resource describes a volume, virtual disk, LUN, or other logical stor
 
 ### Links to other Resources
 
-|Link Name|Destination type
+|Link Name|Destination type|
 |---|---|
 |`Links/Drives[]`|[Drive](ilo6_storage_resourcedefns168/#drive)|
 

--- a/docs/redfishServices/ilos/ilo6/ilo6_changelog.md
+++ b/docs/redfishServices/ilos/ilo6/ilo6_changelog.md
@@ -57,7 +57,7 @@ read the _Redfish versioning_ paragraph of this
     Added `DNSOverRA` [property](/docs/redfishservices/ilos/ilo6/ilo6_168/ilo6_network_resourcedefns168/#ethernetinterface).
 - `EnvironmentMetrics.v1_3_2.EnvironmentMetrics`:
     Added `PowerWatts` [property](/docs/redfishservices/ilos/ilo6/ilo6_168/ilo6_other_resourcedefns168/#powerwatts).
-- `EventDestination.v1_13_0.EventDestination` updated to [version v1\_14\_0](/docs/redfishservices/ilos/ilo6/ilo6_168/       ilo6_other_resourcedefns168/#subscriptiontype).
+- `EventDestination.v1_13_0.EventDestination` updated to [version v1\_14\_0](/docs/redfishservices/ilos/ilo6/ilo6_168/ilo6_other_resourcedefns168/#subscriptiontype).
     Added the following properties: `SyslogTLS`, `SyslogUDP`.
     For more information, see [Syslog subscription](/docs/redfishservices/ilos/supplementdocuments/iloeventservices/#syslog-subscription).
 - `HpeEventService.v2_2_0.HpeEventService`:


### PR DESCRIPTION
Ex of fix:  Missing "|" at end of some tables ; Added empty line after header2 collection headers....